### PR TITLE
[API](*) BUG-FIX: ReadCredential panic

### DIFF
--- a/api/utils/main.go
+++ b/api/utils/main.go
@@ -438,7 +438,7 @@ func (sshPayload *SSHPayload) SSHExecute(logging logger.Logger, flag int, script
 func UserInputCredentials() (string, error) {
 
 	fmt.Print("    Enter Secret-> ")
-	bytePassword, err := terminal.ReadPassword(0)
+	bytePassword, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Bug Fixes 🐞 
- [x] #77

## Solution ✔️ 
- Updated `terminal.ReadPassword(0)` to `terminal.ReadPassword(int(os.Stdin.Fd()))` in `api/utils/main.go`.
