### PR TITLE
fix(API): (*) SSH no host key checks

### DIFF
--- a/api/azure/ha_main.go
+++ b/api/azure/ha_main.go
@@ -26,10 +26,6 @@ func haCreateClusterHandler(ctx context.Context, logger log.Logger, obj *AzurePr
 		return fmt.Errorf("region {%s} is invalid", obj.Region)
 	}
 
-	if isPresent("ha", *obj) {
-		return fmt.Errorf("cluster already exists: %v", obj.ClusterName)
-	}
-
 	logger.Info("Started to Create your HA cluster on Azure provider...", "")
 	defer obj.ConfigWriter(logger, "ha")
 

--- a/api/azure/main.go
+++ b/api/azure/main.go
@@ -248,6 +248,9 @@ func (obj *AzureProvider) CreateCluster(logging log.Logger) error {
 	if obj.HACluster {
 		obj.Config.ResourceGroupName = obj.ClusterName + "-ha-ksctl"
 
+		if isPresent("ha", *obj) {
+			return fmt.Errorf("cluster already exists: %v", obj.ClusterName)
+		}
 		err := haCreateClusterHandler(ctx, logging, obj)
 		if err != nil {
 			logging.Err("CLEANUP TRIGGERED!: failed to create")
@@ -257,6 +260,9 @@ func (obj *AzureProvider) CreateCluster(logging log.Logger) error {
 	} else {
 		obj.Config.ResourceGroupName = obj.ClusterName + "-ksctl"
 
+		if isPresent("managed", *obj) {
+			return fmt.Errorf("cluster already exists: %v", obj.ClusterName)
+		}
 		_, err := managedCreateClusterHandler(ctx, logging, obj)
 		if err != nil {
 			logging.Err("CLEANUP TRIGGERED!: failed to create")
@@ -282,13 +288,20 @@ func (obj *AzureProvider) DeleteCluster(logging log.Logger) error {
 	obj.SSH_Payload = &util.SSHPayload{}
 	if obj.HACluster {
 		obj.Config.ResourceGroupName = obj.ClusterName + "-ha-ksctl"
+		if !isPresent("ha", *obj) {
+			return fmt.Errorf("cluster doesn't exists: %v", obj.ClusterName)
+		}
 		err := haDeleteClusterHandler(ctx, logging, obj, true)
 		if err != nil {
 			return err
 		}
 
 	} else {
+
 		obj.Config.ResourceGroupName = obj.ClusterName + "-ksctl"
+		if !isPresent("managed", *obj) {
+			return fmt.Errorf("cluster doesn't exists: %v", obj.ClusterName)
+		}
 		err := managedDeleteClusterHandler(ctx, logging, obj, true)
 		if err != nil {
 			return err

--- a/api/utils/main.go
+++ b/api/utils/main.go
@@ -386,11 +386,6 @@ func returnServerPublicKeys(publicIP string) (string, error) {
 
 func (sshPayload *SSHPayload) SSHExecute(logging logger.Logger, flag int, script string, fastMode bool) error {
 
-	expectedFingerprint, err := returnServerPublicKeys(sshPayload.PublicIP)
-	if err != nil {
-		return err
-	}
-
 	privateKeyBytes, err := os.ReadFile(sshPayload.PathPrivateKey)
 	if err != nil {
 		return err
@@ -416,6 +411,12 @@ func (sshPayload *SSHPayload) SSHExecute(logging logger.Logger, flag int, script
 				actualFingerprint := ssh.FingerprintSHA256(key)
 				keyType := key.Type()
 				if keyType == ssh.KeyAlgoED25519 {
+					expectedFingerprint, err := returnServerPublicKeys(sshPayload.PublicIP)
+					if err != nil {
+						return err
+					}
+					fmt.Println(actualFingerprint)
+					fmt.Println(expectedFingerprint)
 					if expectedFingerprint != actualFingerprint {
 						return fmt.Errorf("Mismatch of fingerprint")
 					}

--- a/api/utils/main.go
+++ b/api/utils/main.go
@@ -374,6 +374,7 @@ func (sshPayload *SSHPayload) SSHExecute(logging logger.Logger, flag int, script
 		},
 		// FIXME: Remove the InsecureIgnoreHostKey
 		// using the the publickey
+		// ...............
 		// HostKeyCallback: ssh.FixedHostKey(required),
 		// ...............
 		// FOUND THE ROOT cause

--- a/api/utils/main.go
+++ b/api/utils/main.go
@@ -294,7 +294,7 @@ func CreateSSHKeyPair(provider, clusterDir string) (string, error) {
 
 	pathTillFolder := getPaths(provider, "ha", clusterDir)
 
-	cmd := exec.Command("ssh-keygen", "-t", "ed25519", "-N", "", "-f", "keypair")
+	cmd := exec.Command("ssh-keygen", "-t", "rsa", "-N", "", "-f", "keypair")
 	cmd.Dir = pathTillFolder
 	out, err := cmd.Output()
 	if err != nil {
@@ -344,7 +344,7 @@ func signerFromPem(pemBytes []byte) (ssh.Signer, error) {
 }
 
 func returnServerPublicKeys(publicIP string) (string, error) {
-	c1 := exec.Command("ssh-keyscan", "-t", "ed25519", publicIP)
+	c1 := exec.Command("ssh-keyscan", "-t", "rsa", publicIP)
 	c2 := exec.Command("ssh-keygen", "-lf", "-")
 
 	r, w := io.Pipe()
@@ -404,19 +404,19 @@ func (sshPayload *SSHPayload) SSHExecute(logging logger.Logger, flag int, script
 		},
 
 		HostKeyAlgorithms: []string{
-			ssh.KeyAlgoED25519,
+			ssh.KeyAlgoRSASHA256,
 		},
 		HostKeyCallback: ssh.HostKeyCallback(
 			func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 				actualFingerprint := ssh.FingerprintSHA256(key)
 				keyType := key.Type()
-				if keyType == ssh.KeyAlgoED25519 {
+				if keyType == ssh.KeyAlgoRSA {
 					expectedFingerprint, err := returnServerPublicKeys(sshPayload.PublicIP)
 					if err != nil {
 						return err
 					}
 					if expectedFingerprint != actualFingerprint {
-						return fmt.Errorf("Mismatch of fingerprint")
+						return fmt.Errorf("mismatch of fingerprint")
 					}
 					return nil
 				}

--- a/api/utils/main.go
+++ b/api/utils/main.go
@@ -415,8 +415,6 @@ func (sshPayload *SSHPayload) SSHExecute(logging logger.Logger, flag int, script
 					if err != nil {
 						return err
 					}
-					fmt.Println(actualFingerprint)
-					fmt.Println(expectedFingerprint)
 					if expectedFingerprint != actualFingerprint {
 						return fmt.Errorf("Mismatch of fingerprint")
 					}


### PR DESCRIPTION
<!-- FORMAT of PRs
Title should be:
[--Topic-- Example: CLI or API or DOCS or TEST](provider) <PRs title>
-->



<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

# Tasks / Issue :construction: 🔧 
as Not properly verifying the host key returned by a server provides attackers with an opportunity to perform a Machine-in-the-Middle (MitM) attack. A successful attack can compromise the confidentiality and integrity of the information communicated with the server.
- [x] https://github.com/kubesimplify/ksctl/security/code-scanning/22
- [x] #47
even tried using fixedhost but failed
```go
HostKeyCallback: ssh.FixedHostKey(publicKey),
```
<!-- List all the proposed changes in your PR. Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
- [x] Correct; marked as done
- [X] Correct; marked as done

[ ] - Not correct; marked as **not** done
-->
https://github.com/kubesimplify/ksctl/blob/9d9cd3b8f701ae1db08223b28d89a44bd57993ba/api/utils/main.go#L345

# Solution :heavy_check_mark:
- [x] make ssh keys of type ed25519
- [x] create a function which can ssh-keyscan the sepected key fingerprint
- [x] specify the KeyAlgorithm in sshConfig and make a custom logic to verify the hotkey config

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->


# Screenshots :framed_picture:

Solution found!
![image](https://user-images.githubusercontent.com/65275144/229710239-dacc8ac1-61c8-4c6b-9091-bdc4d9a55e40.png)

<!-- Add all the screenshots which support your changes -->

# Note to reviewers :notebook:
Trying to recognize where can they be equal

for version: `v1.0.1-rc2`
<!-- Add notes to reviewers if applicable -->
