### PR TITLE
fix: fixed the x509 cert error

### DIFF
--- a/api/azure/controlplane.go
+++ b/api/azure/controlplane.go
@@ -12,7 +12,7 @@ import (
 	util "github.com/kubesimplify/ksctl/api/utils"
 )
 
-func scriptWithoutCP_1(dbEndpoint, privateIPlb string) string {
+func scriptWithoutCP_1(dbEndpoint, pubIPlb string) string {
 
 	return fmt.Sprintf(`#!/bin/bash
 cat <<EOF > control-setup.sh
@@ -25,7 +25,7 @@ EOF
 
 sudo chmod +x control-setup.sh
 sudo ./control-setup.sh
-`, dbEndpoint, privateIPlb)
+`, dbEndpoint, pubIPlb)
 }
 
 func scriptWithCP_1() string {
@@ -34,7 +34,7 @@ sudo cat /var/lib/rancher/k3s/server/token
 `
 }
 
-func scriptCP_n(dbEndpoint, privateIPlb, token string) string {
+func scriptCP_n(dbEndpoint, pubIPlb, token string) string {
 	return fmt.Sprintf(`#!/bin/bash
 cat <<EOF > control-setupN.sh
 #!/bin/bash
@@ -43,7 +43,7 @@ EOF
 log.Println
 sudo chmod +x control-setupN.sh
 sudo ./control-setupN.sh
-`, token, dbEndpoint, privateIPlb)
+`, token, dbEndpoint, pubIPlb)
 }
 
 func scriptKUBECONFIG() string {

--- a/api/azure/ha_main.go
+++ b/api/azure/ha_main.go
@@ -71,10 +71,10 @@ func haCreateClusterHandler(ctx context.Context, logger log.Logger, obj *AzurePr
 
 	token := ""
 	mysqlEndpoint := obj.Config.DBEndpoint
-	loadBalancerPrivateIP := obj.Config.InfoLoadBalancer.PrivateIP
+	loadBalancerPubIP := obj.Config.InfoLoadBalancer.PublicIP
 	for i := 0; i < obj.Spec.HAControlPlaneNodes; i++ {
 		if i == 0 {
-			err = obj.HelperExecNoOutputControlPlane(logger, obj.Config.InfoControlPlanes.PublicIPs[i], scriptWithoutCP_1(mysqlEndpoint, loadBalancerPrivateIP), true)
+			err = obj.HelperExecNoOutputControlPlane(logger, obj.Config.InfoControlPlanes.PublicIPs[i], scriptWithoutCP_1(mysqlEndpoint, loadBalancerPubIP), true)
 			if err != nil {
 				return err
 			}
@@ -84,7 +84,7 @@ func haCreateClusterHandler(ctx context.Context, logger log.Logger, obj *AzurePr
 				return fmt.Errorf("🚨 Cannot retrieve k3s token")
 			}
 		} else {
-			err = obj.HelperExecNoOutputControlPlane(logger, obj.Config.InfoControlPlanes.PublicIPs[i], scriptCP_n(mysqlEndpoint, loadBalancerPrivateIP, token), true)
+			err = obj.HelperExecNoOutputControlPlane(logger, obj.Config.InfoControlPlanes.PublicIPs[i], scriptCP_n(mysqlEndpoint, loadBalancerPubIP, token), true)
 			if err != nil {
 				return err
 			}
@@ -119,9 +119,9 @@ func haCreateClusterHandler(ctx context.Context, logger log.Logger, obj *AzurePr
 	var printKubeconfig util.PrinterKubeconfigPATH
 	printKubeconfig = printer{ClusterName: obj.ClusterName, Region: obj.Region, ResourceName: obj.Config.ResourceGroupName}
 	printKubeconfig.Printer(logger, true, 0)
-	if err := util.SendFirstRequest(logger, obj.Config.InfoLoadBalancer.PublicIP); err != nil {
-		return err
-	}
+	// if err := util.SendFirstRequest(logger, obj.Config.InfoLoadBalancer.PublicIP); err != nil {
+	// 	return err
+	// }
 	return nil
 }
 

--- a/api/civo/controlplane.go
+++ b/api/civo/controlplane.go
@@ -19,18 +19,14 @@ import (
 )
 
 // scriptWithoutCP_1 script used to configure the control-plane-1 with no need of output inital
-// params
-//
-//	dbEndpoint: database-Endpoint
-//	privateIPlb: private IP of loadbalancer
-func scriptWithoutCP_1(dbEndpoint, privateIPlb string) string {
+func scriptWithoutCP_1(dbEndpoint, pubIPlb string) string {
 
 	return fmt.Sprintf(`#!/bin/bash
 export K3S_DATASTORE_ENDPOINT='%s'
-export INSTALL_K3S_EXEC='--tls-san %s 0.0.0.0/0'
+export INSTALL_K3S_EXEC='--tls-san %s'
 curl -sfL https://get.k3s.io | sh -s - server \
 	--node-taint CriticalAddonsOnly=true:NoExecute
-`, dbEndpoint, privateIPlb)
+`, dbEndpoint, pubIPlb)
 
 	// NOTE: Feature to add other CNI like Cilium
 	// Add these tags for having different CNI
@@ -53,15 +49,15 @@ cat /var/lib/rancher/k3s/server/token
 `
 }
 
-func scriptCP_n(dbEndpoint, privateIPlb, token string) string {
+func scriptCP_n(dbEndpoint, pubIPlb, token string) string {
 	return fmt.Sprintf(`#!/bin/bash
 export SECRET='%s'
 export K3S_DATASTORE_ENDPOINT='%s'
-export INSTALL_K3S_EXEC='--tls-san %s 0.0.0.0/0'
+export INSTALL_K3S_EXEC='--tls-san %s'
 curl -sfL https://get.k3s.io | sh -s - server \
 	--token=$SECRET \
 	--node-taint CriticalAddonsOnly=true:NoExecute
-`, token, dbEndpoint, privateIPlb)
+`, token, dbEndpoint, pubIPlb)
 
 	// NOTE: Feature to add other CNI like Cilium
 	// Add these tags for having different CNI

--- a/api/civo/ha_main.go
+++ b/api/civo/ha_main.go
@@ -150,7 +150,7 @@ func haCreateClusterHandler(logging log.Logger, name, region, nodeSize string, n
 	token := ""
 	for i := 0; i < noCP; i++ {
 		if i == 0 {
-			err = obj.HelperExecNoOutputControlPlane(logging, controlPlanes[i].PublicIP, scriptWithoutCP_1(mysqlEndpoint, loadBalancer.PrivateIP), true)
+			err = obj.HelperExecNoOutputControlPlane(logging, controlPlanes[i].PublicIP, scriptWithoutCP_1(mysqlEndpoint, loadBalancer.PublicIP), true)
 			if err != nil {
 				return err
 			}
@@ -160,7 +160,7 @@ func haCreateClusterHandler(logging log.Logger, name, region, nodeSize string, n
 				return fmt.Errorf("🚨 Cannot retrieve k3s token")
 			}
 		} else {
-			err = obj.HelperExecNoOutputControlPlane(logging, controlPlanes[i].PublicIP, scriptCP_n(mysqlEndpoint, loadBalancer.PrivateIP, token), true)
+			err = obj.HelperExecNoOutputControlPlane(logging, controlPlanes[i].PublicIP, scriptCP_n(mysqlEndpoint, loadBalancer.PublicIP, token), true)
 			if err != nil {
 				return err
 			}
@@ -197,9 +197,9 @@ func haCreateClusterHandler(logging log.Logger, name, region, nodeSize string, n
 	var printKubeconfig util.PrinterKubeconfigPATH
 	printKubeconfig = printer{ClusterName: name, Region: region}
 	printKubeconfig.Printer(logging, true, 0)
-	if err := util.SendFirstRequest(logging, loadBalancer.PublicIP); err != nil {
-		return err
-	}
+	// if err := util.SendFirstRequest(logging, loadBalancer.PublicIP); err != nil {
+	// 	return err
+	// }
 	return nil
 }
 

--- a/api/utils/main.go
+++ b/api/utils/main.go
@@ -9,7 +9,6 @@ package utils
 
 import (
 	"bytes"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -17,7 +16,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"os"
 	"os/exec"
 	"regexp"
@@ -488,32 +486,5 @@ func IsValidNoOfControlPlanes(noCP int) error {
 	if noCP < 3 || (noCP)&1 == 0 {
 		return fmt.Errorf("no of controlplanes must be >= 3 and should be odd number")
 	}
-	return nil
-}
-
-// NOTE: Temporary solution for the x509 certificate issue
-func SendFirstRequest(logging logger.Logger, ip string) error {
-
-	// curl -vk https://74.220.21.225:6443
-	if logging.Verbose {
-		logging.Note("Sending curl request curl -vk to loadbalancer publicIP")
-	}
-
-	// TODO: This is insecure; use only in dev environments.
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	client := &http.Client{Transport: tr}
-
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s:6443", ip), nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
 	return nil
 }


### PR DESCRIPTION
# Tasks description :construction: 🔧 
it fixes the x509 certificate error for not valid IP address range

<!-- add relevant issues and PRs -->
- [x] Closes #105 
- [x] https://github.com/kubesimplify/ksctl/security/code-scanning/24


# Solution :heavy_check_mark:
used `--tls-san` field in k3s install in server to provide the loadbalancer publicIP for cert signing

# Note to reviewers :notebook:
it is a continuation of left over version 1.0 release