### PR TITLE
enhancement: added context for powershell to windows install scripts

### DIFF
--- a/website/docs/getting-started/install.md
+++ b/website/docs/getting-started/install.md
@@ -27,7 +27,7 @@ zsh <(curl -s https://raw.githubusercontent.com/kubesimplify/ksctl/main/install.
 ```
 
   </TabItem>
-  <TabItem value="Windows" label="Windows">
+  <TabItem value="Windows(Powershell)" label="Windows">
 
 ```ps1
 iwr -useb https://raw.githubusercontent.com/kubesimplify/ksctl/main/install.ps1 | iex


### PR DESCRIPTION
# Tasks description :construction: 🔧 

The command only works for Powershell and not CMD
- [x] Closes #113 


# Solution :heavy_check_mark:
The single command only works for Powershell and not CMD. This point is specified for the new user in this commit.

# Note to reviewers :notebook:
NONE


