### PR TITLE
Standardize Kubelet system-reserved and eviction configurations

### DIFF
--- a/pkg/bootstrap/distributions/k3s/controlplane.go
+++ b/pkg/bootstrap/distributions/k3s/controlplane.go
@@ -211,6 +211,10 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
 	--flannel-backend=none \
 	--disable-network-policy \
+	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="cgroup-driver=systemd" \
 	--tls-san %s \
 	--tls-san %s
 EOF
@@ -247,6 +251,10 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-cafile=/var/lib/etcd/ca.pem \
 	--datastore-keyfile=/var/lib/etcd/etcd-key.pem \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
+	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="cgroup-driver=systemd" \
 	--tls-san %s \
 	--tls-san %s
 EOF
@@ -299,6 +307,10 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-keyfile=/var/lib/etcd/etcd-key.pem \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
 	--node-taint CriticalAddonsOnly=true:NoExecute \
+	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="cgroup-driver=systemd" \
 	--server https://%s:6443 \
     --tls-san %s \
     --tls-san %s
@@ -339,6 +351,10 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--node-taint CriticalAddonsOnly=true:NoExecute \
 	--flannel-backend=none \
 	--disable-network-policy \
+	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="cgroup-driver=systemd" \
 	--server https://%s:6443 \
     --tls-san %s \
     --tls-san %s

--- a/pkg/bootstrap/distributions/k3s/controlplane.go
+++ b/pkg/bootstrap/distributions/k3s/controlplane.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ksctl/ksctl/v2/pkg/bootstrap/distributions"
 	"github.com/ksctl/ksctl/v2/pkg/consts"
 	"github.com/ksctl/ksctl/v2/pkg/ssh"
 	"github.com/ksctl/ksctl/v2/pkg/statefile"
@@ -197,7 +198,7 @@ func scriptCP_1WithoutCNI(ca, etcd, key, ver string, privateEtcdIps []string,
 		MaxRetries:     9,
 		CanRetry:       true,
 		ScriptExecutor: consts.LinuxBash,
-		ShellScript: fmt.Sprintf(`
+		ShellScript: fmt.Sprintf(`%s
 cat <<EOF > control-setup.sh
 #!/bin/bash
 
@@ -211,17 +212,16 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
 	--flannel-backend=none \
 	--disable-network-policy \
-	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
-	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
+	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
 	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
-	--kubelet-arg="cgroup-driver=systemd" \
 	--tls-san %s \
 	--tls-san %s
 EOF
 
 sudo chmod +x control-setup.sh
 sudo ./control-setup.sh &>> ksctl.log
-`, ver, dbEndpoint, pubIPlb, privIplb),
+`, distributions.KubeletReservationScript, ver, dbEndpoint, pubIPlb, privIplb),
 	})
 
 	return collection
@@ -241,7 +241,7 @@ func scriptCP_1(ca, etcd, key, ver string, privateEtcdIps []string, pubIPlb,
 		MaxRetries:     9,
 		CanRetry:       true,
 		ScriptExecutor: consts.LinuxBash,
-		ShellScript: fmt.Sprintf(`
+		ShellScript: fmt.Sprintf(`%s
 cat <<EOF > control-setup.sh
 #!/bin/bash
 /bin/bash /usr/local/bin/k3s-uninstall.sh || echo "already deleted"
@@ -251,17 +251,16 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-cafile=/var/lib/etcd/ca.pem \
 	--datastore-keyfile=/var/lib/etcd/etcd-key.pem \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
-	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
-	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
+	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
 	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
-	--kubelet-arg="cgroup-driver=systemd" \
 	--tls-san %s \
 	--tls-san %s
 EOF
 
 sudo chmod +x control-setup.sh
 sudo ./control-setup.sh &>> ksctl.log
-`, ver, dbEndpoint, pubIPlb, privateIPLb),
+`, distributions.KubeletReservationScript, ver, dbEndpoint, pubIPlb, privateIPLb),
 	})
 
 	return collection
@@ -296,7 +295,7 @@ func scriptCP_N(ca, etcd, key, ver string, privateEtcdIps []string,
 		MaxRetries:     9,
 		CanRetry:       true,
 		ScriptExecutor: consts.LinuxBash,
-		ShellScript: fmt.Sprintf(`
+		ShellScript: fmt.Sprintf(`%s
 cat <<EOF > control-setupN.sh
 #!/bin/bash
 /bin/bash /usr/local/bin/k3s-uninstall.sh || echo "already deleted"
@@ -307,10 +306,9 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-keyfile=/var/lib/etcd/etcd-key.pem \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
 	--node-taint CriticalAddonsOnly=true:NoExecute \
-	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
-	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
+	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
 	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
-	--kubelet-arg="cgroup-driver=systemd" \
 	--server https://%s:6443 \
     --tls-san %s \
     --tls-san %s
@@ -318,7 +316,7 @@ EOF
 
 sudo chmod +x control-setupN.sh
 sudo ./control-setupN.sh &>> ksctl.log
-`, ver, token, dbEndpoint, privateIPlb, pubIplb, privateIPlb),
+`, distributions.KubeletReservationScript, ver, token, dbEndpoint, privateIPlb, pubIplb, privateIPlb),
 	})
 
 	return collection
@@ -338,7 +336,7 @@ func scriptCP_NWithoutCNI(ca, etcd, key, ver string, privateEtcdIps []string,
 		MaxRetries:     9,
 		CanRetry:       true,
 		ScriptExecutor: consts.LinuxBash,
-		ShellScript: fmt.Sprintf(`
+		ShellScript: fmt.Sprintf(`%s
 cat <<EOF > control-setupN.sh
 #!/bin/bash
 /bin/bash /usr/local/bin/k3s-uninstall.sh || echo "already deleted"
@@ -351,10 +349,9 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--node-taint CriticalAddonsOnly=true:NoExecute \
 	--flannel-backend=none \
 	--disable-network-policy \
-	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
-	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
+	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
 	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
-	--kubelet-arg="cgroup-driver=systemd" \
 	--server https://%s:6443 \
     --tls-san %s \
     --tls-san %s
@@ -362,7 +359,7 @@ EOF
 
 sudo chmod +x control-setupN.sh
 sudo ./control-setupN.sh &>> ksctl.log
-`, ver, token, dbEndpoint, privateIPlb, pubIplb, privateIPlb),
+`, distributions.KubeletReservationScript, ver, token, dbEndpoint, privateIPlb, pubIplb, privateIPlb),
 	})
 
 	return collection

--- a/pkg/bootstrap/distributions/k3s/controlplane.go
+++ b/pkg/bootstrap/distributions/k3s/controlplane.go
@@ -214,7 +214,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--disable-network-policy \
 	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
 	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
-	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,nodefs.inodesFree<5%%,imagefs.available<15%%" \
 	--tls-san %s \
 	--tls-san %s
 EOF
@@ -253,7 +253,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
 	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
 	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
-	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,nodefs.inodesFree<5%%,imagefs.available<15%%" \
 	--tls-san %s \
 	--tls-san %s
 EOF
@@ -308,7 +308,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--node-taint CriticalAddonsOnly=true:NoExecute \
 	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
 	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
-	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,nodefs.inodesFree<5%%,imagefs.available<15%%" \
 	--server https://%s:6443 \
     --tls-san %s \
     --tls-san %s
@@ -351,7 +351,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--disable-network-policy \
 	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
 	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
-	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,nodefs.inodesFree<5%%,imagefs.available<15%%" \
 	--server https://%s:6443 \
     --tls-san %s \
     --tls-san %s

--- a/pkg/bootstrap/distributions/k3s/k3s_test.go
+++ b/pkg/bootstrap/distributions/k3s/k3s_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ksctl/ksctl/v2/pkg/addons"
 
+	"github.com/ksctl/ksctl/v2/pkg/bootstrap/distributions"
 	"github.com/ksctl/ksctl/v2/pkg/certs"
 	"github.com/ksctl/ksctl/v2/pkg/ssh"
 	testHelper "github.com/ksctl/ksctl/v2/pkg/ssh"
@@ -114,7 +115,7 @@ func TestScriptsControlplane(t *testing.T) {
 							MaxRetries:     9,
 							CanRetry:       true,
 							ScriptExecutor: consts.LinuxBash,
-							ShellScript: fmt.Sprintf(`
+							ShellScript: fmt.Sprintf(`%s
 cat <<EOF > control-setup.sh
 #!/bin/bash
 
@@ -128,17 +129,16 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
 	--flannel-backend=none \
 	--disable-network-policy \
-	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
-	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
+	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
 	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
-	--kubelet-arg="cgroup-driver=systemd" \
 	--tls-san %s \
 	--tls-san %s
 EOF
 
 sudo chmod +x control-setup.sh
 sudo ./control-setup.sh &>> ksctl.log
-`, ver[i], dbEndpoint, pubIPLb[i], privateIPLb[i]),
+`, distributions.KubeletReservationScript, ver[i], dbEndpoint, pubIPLb[i], privateIPLb[i]),
 						},
 					},
 					func() ssh.ExecutionPipeline { // Adjust the signature to match your needs
@@ -160,7 +160,7 @@ sudo ./control-setup.sh &>> ksctl.log
 							MaxRetries:     9,
 							CanRetry:       true,
 							ScriptExecutor: consts.LinuxBash,
-							ShellScript: fmt.Sprintf(`
+							ShellScript: fmt.Sprintf(`%s
 cat <<EOF > control-setup.sh
 #!/bin/bash
 /bin/bash /usr/local/bin/k3s-uninstall.sh || echo "already deleted"
@@ -170,17 +170,16 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-cafile=/var/lib/etcd/ca.pem \
 	--datastore-keyfile=/var/lib/etcd/etcd-key.pem \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
-	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
-	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
+	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
 	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
-	--kubelet-arg="cgroup-driver=systemd" \
 	--tls-san %s \
 	--tls-san %s
 EOF
 
 sudo chmod +x control-setup.sh
 sudo ./control-setup.sh &>> ksctl.log
-`, ver[i], dbEndpoint, pubIPLb[i], privateIPLb[i]),
+`, distributions.KubeletReservationScript, ver[i], dbEndpoint, pubIPLb[i], privateIPLb[i]),
 						},
 					},
 					func() ssh.ExecutionPipeline { // Adjust the signature to match your needs
@@ -206,7 +205,7 @@ sudo ./control-setup.sh &>> ksctl.log
 							MaxRetries:     9,
 							CanRetry:       true,
 							ScriptExecutor: consts.LinuxBash,
-							ShellScript: fmt.Sprintf(`
+							ShellScript: fmt.Sprintf(`%s
 cat <<EOF > control-setupN.sh
 #!/bin/bash
 /bin/bash /usr/local/bin/k3s-uninstall.sh || echo "already deleted"
@@ -219,10 +218,9 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--node-taint CriticalAddonsOnly=true:NoExecute \
 	--flannel-backend=none \
 	--disable-network-policy \
-	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
-	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
+	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
 	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
-	--kubelet-arg="cgroup-driver=systemd" \
 	--server https://%s:6443 \
     --tls-san %s \
     --tls-san %s
@@ -230,7 +228,7 @@ EOF
 
 sudo chmod +x control-setupN.sh
 sudo ./control-setupN.sh &>> ksctl.log
-`, ver[i], sampleToken, dbEndpoint, privateIPLb[i], pubIPLb[i], privateIPLb[i]),
+`, distributions.KubeletReservationScript, ver[i], sampleToken, dbEndpoint, privateIPLb[i], pubIPLb[i], privateIPLb[i]),
 						},
 					},
 					func() ssh.ExecutionPipeline { // Adjust the signature to match your needs
@@ -252,7 +250,7 @@ sudo ./control-setupN.sh &>> ksctl.log
 							MaxRetries:     9,
 							CanRetry:       true,
 							ScriptExecutor: consts.LinuxBash,
-							ShellScript: fmt.Sprintf(`
+							ShellScript: fmt.Sprintf(`%s
 cat <<EOF > control-setupN.sh
 #!/bin/bash
 /bin/bash /usr/local/bin/k3s-uninstall.sh || echo "already deleted"
@@ -263,10 +261,9 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-keyfile=/var/lib/etcd/etcd-key.pem \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
 	--node-taint CriticalAddonsOnly=true:NoExecute \
-	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
-	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
+	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
 	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
-	--kubelet-arg="cgroup-driver=systemd" \
 	--server https://%s:6443 \
     --tls-san %s \
     --tls-san %s
@@ -274,7 +271,7 @@ EOF
 
 sudo chmod +x control-setupN.sh
 sudo ./control-setupN.sh &>> ksctl.log
-`, ver[i], sampleToken, dbEndpoint, privateIPLb[i], pubIPLb[i], privateIPLb[i]),
+`, distributions.KubeletReservationScript, ver[i], sampleToken, dbEndpoint, privateIPLb[i], pubIPLb[i], privateIPLb[i]),
 						},
 					},
 					func() ssh.ExecutionPipeline { // Adjust the signature to match your needs
@@ -339,21 +336,20 @@ func TestSciprWorkerplane(t *testing.T) {
 					CanRetry:       true,
 					MaxRetries:     3,
 					ScriptExecutor: consts.LinuxBash,
-					ShellScript: fmt.Sprintf(`
+					ShellScript: fmt.Sprintf(`%s
 cat <<EOF > worker-setup.sh
 #!/bin/bash
 /bin/bash /usr/local/bin/k3s-agent-uninstall.sh || echo "already deleted"
 export K3S_DEBUG=true
 curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - agent --token %s --server https://%s:6443 \
-	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
-	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
-	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
-	--kubelet-arg="cgroup-driver=systemd"
+	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
+	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%"
 EOF
 
 sudo chmod +x worker-setup.sh
 sudo ./worker-setup.sh &>> ksctl.log
-`, ver, token, private),
+`, distributions.KubeletReservationScript, ver, token, private),
 				},
 			},
 			func() ssh.ExecutionPipeline { // Adjust the signature to match your needs

--- a/pkg/bootstrap/distributions/k3s/k3s_test.go
+++ b/pkg/bootstrap/distributions/k3s/k3s_test.go
@@ -131,7 +131,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--disable-network-policy \
 	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
 	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
-	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,nodefs.inodesFree<5%%,imagefs.available<15%%" \
 	--tls-san %s \
 	--tls-san %s
 EOF
@@ -172,7 +172,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
 	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
 	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
-	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,nodefs.inodesFree<5%%,imagefs.available<15%%" \
 	--tls-san %s \
 	--tls-san %s
 EOF
@@ -220,7 +220,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--disable-network-policy \
 	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
 	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
-	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,nodefs.inodesFree<5%%,imagefs.available<15%%" \
 	--server https://%s:6443 \
     --tls-san %s \
     --tls-san %s
@@ -263,7 +263,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--node-taint CriticalAddonsOnly=true:NoExecute \
 	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
 	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
-	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,nodefs.inodesFree<5%%,imagefs.available<15%%" \
 	--server https://%s:6443 \
     --tls-san %s \
     --tls-san %s
@@ -344,7 +344,7 @@ export K3S_DEBUG=true
 curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - agent --token %s --server https://%s:6443 \
 	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
 	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
-	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%"
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,nodefs.inodesFree<5%%,imagefs.available<15%%"
 EOF
 
 sudo chmod +x worker-setup.sh

--- a/pkg/bootstrap/distributions/k3s/k3s_test.go
+++ b/pkg/bootstrap/distributions/k3s/k3s_test.go
@@ -128,6 +128,10 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
 	--flannel-backend=none \
 	--disable-network-policy \
+	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="cgroup-driver=systemd" \
 	--tls-san %s \
 	--tls-san %s
 EOF
@@ -166,6 +170,10 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-cafile=/var/lib/etcd/ca.pem \
 	--datastore-keyfile=/var/lib/etcd/etcd-key.pem \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
+	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="cgroup-driver=systemd" \
 	--tls-san %s \
 	--tls-san %s
 EOF
@@ -211,6 +219,10 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--node-taint CriticalAddonsOnly=true:NoExecute \
 	--flannel-backend=none \
 	--disable-network-policy \
+	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="cgroup-driver=systemd" \
 	--server https://%s:6443 \
     --tls-san %s \
     --tls-san %s
@@ -251,6 +263,10 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - server \
 	--datastore-keyfile=/var/lib/etcd/etcd-key.pem \
 	--datastore-certfile=/var/lib/etcd/etcd.pem \
 	--node-taint CriticalAddonsOnly=true:NoExecute \
+	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="cgroup-driver=systemd" \
 	--server https://%s:6443 \
     --tls-san %s \
     --tls-san %s
@@ -328,7 +344,11 @@ cat <<EOF > worker-setup.sh
 #!/bin/bash
 /bin/bash /usr/local/bin/k3s-agent-uninstall.sh || echo "already deleted"
 export K3S_DEBUG=true
-curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - agent --token %s --server https://%s:6443
+curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - agent --token %s --server https://%s:6443 \
+	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="cgroup-driver=systemd"
 EOF
 
 sudo chmod +x worker-setup.sh

--- a/pkg/bootstrap/distributions/k3s/workerplane.go
+++ b/pkg/bootstrap/distributions/k3s/workerplane.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/ksctl/ksctl/v2/pkg/bootstrap/distributions"
 	"github.com/ksctl/ksctl/v2/pkg/consts"
 	"github.com/ksctl/ksctl/v2/pkg/ssh"
 )
@@ -57,21 +58,20 @@ func scriptWP(ver string, privateIPlb, token string) ssh.ExecutionPipeline {
 		CanRetry:       true,
 		MaxRetries:     3,
 		ScriptExecutor: consts.LinuxBash,
-		ShellScript: fmt.Sprintf(`
+		ShellScript: fmt.Sprintf(`%s
 cat <<EOF > worker-setup.sh
 #!/bin/bash
 /bin/bash /usr/local/bin/k3s-agent-uninstall.sh || echo "already deleted"
 export K3S_DEBUG=true
 curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - agent --token %s --server https://%s:6443 \
-	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
-	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
-	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
-	--kubelet-arg="cgroup-driver=systemd"
+	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
+	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%"
 EOF
 
 sudo chmod +x worker-setup.sh
 sudo ./worker-setup.sh &>> ksctl.log
-`, ver, token, privateIPlb),
+`, distributions.KubeletReservationScript, ver, token, privateIPlb),
 	})
 
 	return collection

--- a/pkg/bootstrap/distributions/k3s/workerplane.go
+++ b/pkg/bootstrap/distributions/k3s/workerplane.go
@@ -62,7 +62,11 @@ cat <<EOF > worker-setup.sh
 #!/bin/bash
 /bin/bash /usr/local/bin/k3s-agent-uninstall.sh || echo "already deleted"
 export K3S_DEBUG=true
-curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - agent --token %s --server https://%s:6443
+curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - agent --token %s --server https://%s:6443 \
+	--kubelet-arg="kube-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="system-reserved=cpu=200m,memory=500Mi" \
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%" \
+	--kubelet-arg="cgroup-driver=systemd"
 EOF
 
 sudo chmod +x worker-setup.sh

--- a/pkg/bootstrap/distributions/k3s/workerplane.go
+++ b/pkg/bootstrap/distributions/k3s/workerplane.go
@@ -66,7 +66,7 @@ export K3S_DEBUG=true
 curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL="%s" sh -s - agent --token %s --server https://%s:6443 \
 	--kubelet-arg="kube-reserved=cpu=${KUBE_CPU}m,memory=${KUBE_MEM}Mi" \
 	--kubelet-arg="system-reserved=cpu=100m,memory=200Mi" \
-	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,imagefs.available<15%%"
+	--kubelet-arg="eviction-hard=memory.available<100Mi,nodefs.available<10%%,nodefs.inodesFree<5%%,imagefs.available<15%%"
 EOF
 
 sudo chmod +x worker-setup.sh

--- a/pkg/bootstrap/distributions/kubeadm/controlplane.go
+++ b/pkg/bootstrap/distributions/kubeadm/controlplane.go
@@ -68,6 +68,7 @@ func (p *Kubeadm) configurecp1(sshExecutor ssh.RemoteConnection) error {
 	p.l.Print(p.ctx, "Configuring K8s cluster")
 
 	configureControlPlane0 := scriptAddKubeadmControlplane0(
+		distributions.ScriptKubeletDropIn(ssh.NewExecutionPipeline()),
 		*p.state.Versions.Kubeadm,
 		p.state.K8sBootstrap.Kubeadm.BootstrapToken,
 		p.state.K8sBootstrap.Kubeadm.CertificateKey,
@@ -133,6 +134,7 @@ func (p *Kubeadm) ConfigureControlPlane(noOfCP int) error {
 		p.l.Print(p.ctx, "Joining controlplane to existing cluster")
 		if err := sshExecutor.Flag(consts.UtilExecWithoutOutput).
 			Script(scriptJoinControlplane(
+				distributions.ScriptKubeletDropIn(ssh.NewExecutionPipeline()),
 				p.state.K8sBootstrap.B.PrivateIPs.LoadBalancer,
 				p.state.K8sBootstrap.Kubeadm.BootstrapToken,
 				p.state.K8sBootstrap.Kubeadm.DiscoveryTokenCACertHash,
@@ -216,11 +218,9 @@ kubeadm token create --ttl 20m --description "ksctl bootstrap token"
 	return collection
 }
 
-func scriptAddKubeadmControlplane0(ver string, bootstrapToken, certificateKey, publicIPLb string, privateIpLb string, privateIPDs []string) ssh.ExecutionPipeline {
+func scriptAddKubeadmControlplane0(collection ssh.ExecutionPipeline, ver string, bootstrapToken, certificateKey, publicIPLb string, privateIpLb string, privateIPDs []string) ssh.ExecutionPipeline {
 
 	etcdConf := generateExternalEtcdConfig(privateIPDs)
-
-	collection := ssh.NewExecutionPipeline()
 
 	collection.Append(ssh.Script{
 		Name:       "store configuration for Controlplane0",
@@ -285,6 +285,7 @@ systemReserved:
 evictionHard:
   memory.available: "100Mi"
   nodefs.available: "10%%"
+  nodefs.inodesFree: "5%%"
   imagefs.available: "15%%"
 EOF
 
@@ -372,9 +373,8 @@ sudo mv -v ca.pem etcd.pem etcd-key.pem /etcd/kubernetes/pki/etcd
 	return collection
 }
 
-func scriptJoinControlplane(privateIPLb, token, cacertSHA, certKey string) ssh.ExecutionPipeline {
+func scriptJoinControlplane(collection ssh.ExecutionPipeline, privateIPLb, token, cacertSHA, certKey string) ssh.ExecutionPipeline {
 
-	collection := ssh.NewExecutionPipeline()
 	collection.Append(ssh.Script{
 		Name:           "Join Controlplane [1..N]",
 		CanRetry:       true,

--- a/pkg/bootstrap/distributions/kubeadm/controlplane.go
+++ b/pkg/bootstrap/distributions/kubeadm/controlplane.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ksctl/ksctl/v2/pkg/bootstrap/distributions"
 	"github.com/ksctl/ksctl/v2/pkg/ssh"
 
 	"github.com/ksctl/ksctl/v2/pkg/consts"
@@ -225,7 +226,7 @@ func scriptAddKubeadmControlplane0(ver string, bootstrapToken, certificateKey, p
 		Name:       "store configuration for Controlplane0",
 		CanRetry:   true,
 		MaxRetries: 3,
-		ShellScript: fmt.Sprintf(`
+		ShellScript: fmt.Sprintf(`%s
 cat <<EOF > kubeadm-config.yml
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: InitConfiguration
@@ -275,20 +276,19 @@ scheduler: {}
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-cgroupDriver: systemd
 kubeReserved:
-  cpu: "200m"
-  memory: "500Mi"
+  cpu: "${KUBE_CPU}m"
+  memory: "${KUBE_MEM}Mi"
 systemReserved:
-  cpu: "200m"
-  memory: "500Mi"
+  cpu: "100m"
+  memory: "200Mi"
 evictionHard:
   memory.available: "100Mi"
   nodefs.available: "10%%"
   imagefs.available: "15%%"
 EOF
 
-`, bootstrapToken, certificateKey, publicIPLb, privateIpLb, etcdConf, ver, publicIPLb),
+`, distributions.KubeletReservationScript, bootstrapToken, certificateKey, publicIPLb, privateIpLb, etcdConf, ver, publicIPLb),
 	})
 
 	collection.Append(ssh.Script{

--- a/pkg/bootstrap/distributions/kubeadm/controlplane.go
+++ b/pkg/bootstrap/distributions/kubeadm/controlplane.go
@@ -272,6 +272,20 @@ networking:
   serviceSubnet: 10.96.0.0/12
   podSubnet: 10.244.0.0/16
 scheduler: {}
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: systemd
+kubeReserved:
+  cpu: "200m"
+  memory: "500Mi"
+systemReserved:
+  cpu: "200m"
+  memory: "500Mi"
+evictionHard:
+  memory.available: "100Mi"
+  nodefs.available: "10%%"
+  imagefs.available: "15%%"
 EOF
 
 `, bootstrapToken, certificateKey, publicIPLb, privateIpLb, etcdConf, ver, publicIPLb),

--- a/pkg/bootstrap/distributions/kubeadm/kubeadm_test.go
+++ b/pkg/bootstrap/distributions/kubeadm/kubeadm_test.go
@@ -328,6 +328,20 @@ networking:
   serviceSubnet: 10.96.0.0/12
   podSubnet: 10.244.0.0/16
 scheduler: {}
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: systemd
+kubeReserved:
+  cpu: "200m"
+  memory: "500Mi"
+systemReserved:
+  cpu: "200m"
+  memory: "500Mi"
+evictionHard:
+  memory.available: "100Mi"
+  nodefs.available: "10%%"
+  imagefs.available: "15%%"
 EOF
 
 `, bootstrapToken, certificateKey, publicIPLb, privateIPLb, etcdConf, ver, publicIPLb),

--- a/pkg/bootstrap/distributions/kubeadm/kubeadm_test.go
+++ b/pkg/bootstrap/distributions/kubeadm/kubeadm_test.go
@@ -279,16 +279,10 @@ sudo cat /etc/kubernetes/admin.conf
 			t,
 			[]ssh.Script{
 				{
-					Name:           "compute kubelet reservations",
+					Name:           "compute kubelet reservations and write drop-in config",
 					CanRetry:       false,
 					ScriptExecutor: consts.LinuxBash,
-					ShellScript:    distributions.KubeletReservationScript,
-				},
-				{
-					Name:           "write kubelet drop-in config",
-					CanRetry:       false,
-					ScriptExecutor: consts.LinuxBash,
-					ShellScript:    distributions.KubeletDropInScript,
+					ShellScript:    distributions.KubeletReservationScript + distributions.KubeletDropInScript,
 				},
 				{
 					Name:       "store configuration for Controlplane0",
@@ -387,16 +381,10 @@ sudo chown $(id -u):$(id -g) $HOME/.kube/config
 			t,
 			[]ssh.Script{
 				{
-					Name:           "compute kubelet reservations",
+					Name:           "compute kubelet reservations and write drop-in config",
 					CanRetry:       false,
 					ScriptExecutor: consts.LinuxBash,
-					ShellScript:    distributions.KubeletReservationScript,
-				},
-				{
-					Name:           "write kubelet drop-in config",
-					CanRetry:       false,
-					ScriptExecutor: consts.LinuxBash,
-					ShellScript:    distributions.KubeletDropInScript,
+					ShellScript:    distributions.KubeletReservationScript + distributions.KubeletDropInScript,
 				},
 				{
 					Name:           "Join Controlplane [1..N]",
@@ -457,16 +445,10 @@ func TestSciprWorkerplane(t *testing.T) {
 		t,
 		[]ssh.Script{
 			{
-				Name:           "compute kubelet reservations",
+				Name:           "compute kubelet reservations and write drop-in config",
 				CanRetry:       false,
 				ScriptExecutor: consts.LinuxBash,
-				ShellScript:    distributions.KubeletReservationScript,
-			},
-			{
-				Name:           "write kubelet drop-in config",
-				CanRetry:       false,
-				ScriptExecutor: consts.LinuxBash,
-				ShellScript:    distributions.KubeletDropInScript,
+				ShellScript:    distributions.KubeletReservationScript + distributions.KubeletDropInScript,
 			},
 			{
 				Name:           "Join K3s workerplane",

--- a/pkg/bootstrap/distributions/kubeadm/kubeadm_test.go
+++ b/pkg/bootstrap/distributions/kubeadm/kubeadm_test.go
@@ -19,8 +19,8 @@ import (
 	"testing"
 
 	"github.com/ksctl/ksctl/v2/pkg/addons"
-
 	"github.com/ksctl/ksctl/v2/pkg/bootstrap/distributions"
+
 	"github.com/ksctl/ksctl/v2/pkg/ssh"
 	testHelper "github.com/ksctl/ksctl/v2/pkg/ssh"
 
@@ -279,6 +279,18 @@ sudo cat /etc/kubernetes/admin.conf
 			t,
 			[]ssh.Script{
 				{
+					Name:           "compute kubelet reservations",
+					CanRetry:       false,
+					ScriptExecutor: consts.LinuxBash,
+					ShellScript:    distributions.KubeletReservationScript,
+				},
+				{
+					Name:           "write kubelet drop-in config",
+					CanRetry:       false,
+					ScriptExecutor: consts.LinuxBash,
+					ShellScript:    distributions.KubeletDropInScript,
+				},
+				{
 					Name:       "store configuration for Controlplane0",
 					CanRetry:   true,
 					MaxRetries: 3,
@@ -341,6 +353,7 @@ systemReserved:
 evictionHard:
   memory.available: "100Mi"
   nodefs.available: "10%%"
+  nodefs.inodesFree: "5%%"
   imagefs.available: "15%%"
 EOF
 
@@ -360,7 +373,7 @@ sudo chown $(id -u):$(id -g) $HOME/.kube/config
 				},
 			},
 			func() ssh.ExecutionPipeline { // Adjust the signature to match your needs
-				return scriptAddKubeadmControlplane0(ver, bootstrapToken, certificateKey, publicIPLb, privateIPLb, privateIPDs)
+				return scriptAddKubeadmControlplane0(distributions.ScriptKubeletDropIn(ssh.NewExecutionPipeline()), ver, bootstrapToken, certificateKey, publicIPLb, privateIPLb, privateIPDs)
 			},
 		)
 	})
@@ -374,6 +387,18 @@ sudo chown $(id -u):$(id -g) $HOME/.kube/config
 			t,
 			[]ssh.Script{
 				{
+					Name:           "compute kubelet reservations",
+					CanRetry:       false,
+					ScriptExecutor: consts.LinuxBash,
+					ShellScript:    distributions.KubeletReservationScript,
+				},
+				{
+					Name:           "write kubelet drop-in config",
+					CanRetry:       false,
+					ScriptExecutor: consts.LinuxBash,
+					ShellScript:    distributions.KubeletDropInScript,
+				},
+				{
 					Name:           "Join Controlplane [1..N]",
 					CanRetry:       true,
 					MaxRetries:     3,
@@ -384,7 +409,7 @@ sudo kubeadm join %s:6443 --token %s --discovery-token-ca-cert-hash sha256:%s --
 				},
 			},
 			func() ssh.ExecutionPipeline { // Adjust the signature to match your needs
-				return scriptJoinControlplane(privateIPLb, token, cacertSHA, crtKey)
+				return scriptJoinControlplane(distributions.ScriptKubeletDropIn(ssh.NewExecutionPipeline()), privateIPLb, token, cacertSHA, crtKey)
 			},
 		)
 	})
@@ -432,6 +457,18 @@ func TestSciprWorkerplane(t *testing.T) {
 		t,
 		[]ssh.Script{
 			{
+				Name:           "compute kubelet reservations",
+				CanRetry:       false,
+				ScriptExecutor: consts.LinuxBash,
+				ShellScript:    distributions.KubeletReservationScript,
+			},
+			{
+				Name:           "write kubelet drop-in config",
+				CanRetry:       false,
+				ScriptExecutor: consts.LinuxBash,
+				ShellScript:    distributions.KubeletDropInScript,
+			},
+			{
 				Name:           "Join K3s workerplane",
 				CanRetry:       true,
 				MaxRetries:     3,
@@ -442,7 +479,7 @@ sudo kubeadm join %s:6443 --token %s --discovery-token-ca-cert-hash sha256:%s &>
 			},
 		},
 		func() ssh.ExecutionPipeline { // Adjust the signature to match your needs
-			return scriptJoinWorkerplane(ssh.NewExecutionPipeline(), privateIPLb, token, cacertSHA)
+			return scriptJoinWorkerplane(distributions.ScriptKubeletDropIn(ssh.NewExecutionPipeline()), privateIPLb, token, cacertSHA)
 		},
 	)
 }

--- a/pkg/bootstrap/distributions/kubeadm/kubeadm_test.go
+++ b/pkg/bootstrap/distributions/kubeadm/kubeadm_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ksctl/ksctl/v2/pkg/addons"
 
+	"github.com/ksctl/ksctl/v2/pkg/bootstrap/distributions"
 	"github.com/ksctl/ksctl/v2/pkg/ssh"
 	testHelper "github.com/ksctl/ksctl/v2/pkg/ssh"
 
@@ -281,7 +282,7 @@ sudo cat /etc/kubernetes/admin.conf
 					Name:       "store configuration for Controlplane0",
 					CanRetry:   true,
 					MaxRetries: 3,
-					ShellScript: fmt.Sprintf(`
+					ShellScript: fmt.Sprintf(`%s
 cat <<EOF > kubeadm-config.yml
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: InitConfiguration
@@ -331,20 +332,19 @@ scheduler: {}
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-cgroupDriver: systemd
 kubeReserved:
-  cpu: "200m"
-  memory: "500Mi"
+  cpu: "${KUBE_CPU}m"
+  memory: "${KUBE_MEM}Mi"
 systemReserved:
-  cpu: "200m"
-  memory: "500Mi"
+  cpu: "100m"
+  memory: "200Mi"
 evictionHard:
   memory.available: "100Mi"
   nodefs.available: "10%%"
   imagefs.available: "15%%"
 EOF
 
-`, bootstrapToken, certificateKey, publicIPLb, privateIPLb, etcdConf, ver, publicIPLb),
+`, distributions.KubeletReservationScript, bootstrapToken, certificateKey, publicIPLb, privateIPLb, etcdConf, ver, publicIPLb),
 				},
 				{
 					Name:       "kubeadm init",

--- a/pkg/bootstrap/distributions/kubeadm/workerplane.go
+++ b/pkg/bootstrap/distributions/kubeadm/workerplane.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ksctl/ksctl/v2/pkg/bootstrap/distributions"
 	"github.com/ksctl/ksctl/v2/pkg/ssh"
 
 	"github.com/ksctl/ksctl/v2/pkg/consts"
@@ -71,7 +72,8 @@ func (p *Kubeadm) JoinWorkerplane(noOfWP int) error {
 	}
 
 	script := scriptJoinWorkerplane(
-		scriptInstallKubeadmAndOtherTools(*p.state.Versions.Kubeadm),
+		distributions.ScriptKubeletDropIn(
+			scriptInstallKubeadmAndOtherTools(*p.state.Versions.Kubeadm)),
 		p.state.K8sBootstrap.B.PrivateIPs.LoadBalancer,
 		p.state.K8sBootstrap.Kubeadm.BootstrapToken,
 		p.state.K8sBootstrap.Kubeadm.DiscoveryTokenCACertHash,

--- a/pkg/bootstrap/distributions/kubelet_reservation.go
+++ b/pkg/bootstrap/distributions/kubelet_reservation.go
@@ -14,6 +14,11 @@
 
 package distributions
 
+import (
+	"github.com/ksctl/ksctl/v2/pkg/consts"
+	"github.com/ksctl/ksctl/v2/pkg/ssh"
+)
+
 // KubeletReservation holds computed GKE-style tiered resource reservations.
 type KubeletReservation struct {
 	KubeReservedCPU      int // millicores
@@ -79,11 +84,12 @@ func memReserved(mem int) int {
 //   - KUBE_CPU  – millicores to reserve (e.g. 60, 70, 80)
 //   - KUBE_MEM  – mebibytes to reserve (minimum 255)
 //
-// The snippet is already %%-escaped so it can be embedded directly inside
-// fmt.Sprintf format strings.
+// NOTE: This constant is used via %s in fmt.Sprintf (controlplane.go CP0)
+// and via direct ShellScript assignment (ScriptKubeletDropIn for CP1+/workers).
+// In both cases the string is inserted as-is, so use literal % not %%.
 const KubeletReservationScript = `
 TOTAL_CPUS=$(nproc)
-TOTAL_MEM_MI=$(awk '/MemTotal/{printf "%%d", $2/1024}' /proc/meminfo)
+TOTAL_MEM_MI=$(awk '/MemTotal/{printf "%d", $2/1024}' /proc/meminfo)
 
 cpu_reserved() {
   local cpus=$1
@@ -123,3 +129,55 @@ mem_reserved() {
 KUBE_CPU=$(cpu_reserved "$TOTAL_CPUS")
 KUBE_MEM=$(mem_reserved "$TOTAL_MEM_MI")
 `
+
+// KubeletDropInScript writes a per-node kubelet drop-in config with computed
+// reservations and eviction thresholds, plus enables --config-dir via
+// /etc/default/kubelet. Used for CP1+ and worker nodes where the base config
+// comes from the kubelet-config ConfigMap.
+//
+// NOTE: This constant is assigned directly to ShellScript (not via fmt.Sprintf),
+// so literal % is used for YAML percentage values.
+const KubeletDropInScript = `
+sudo mkdir -p /etc/kubernetes/kubelet.conf.d
+
+sudo tee /etc/kubernetes/kubelet.conf.d/99-reserved.conf > /dev/null <<DROPIN
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+kubeReserved:
+  cpu: "${KUBE_CPU}m"
+  memory: "${KUBE_MEM}Mi"
+systemReserved:
+  cpu: "100m"
+  memory: "200Mi"
+evictionHard:
+  memory.available: "100Mi"
+  nodefs.available: "10%"
+  nodefs.inodesFree: "5%"
+  imagefs.available: "15%"
+DROPIN
+
+echo 'KUBELET_EXTRA_ARGS=--config-dir=/etc/kubernetes/kubelet.conf.d' | sudo tee /etc/default/kubelet > /dev/null
+`
+
+// ScriptKubeletDropIn appends kubelet reservation and drop-in configuration
+// steps to the given execution pipeline. It computes per-node kubeReserved
+// and systemReserved values from local hardware using a GKE-style tiered
+// formula, then writes a kubelet drop-in config file and enables --config-dir.
+// Used for CP1+ and worker nodes.
+func ScriptKubeletDropIn(collection ssh.ExecutionPipeline) ssh.ExecutionPipeline {
+	collection.Append(ssh.Script{
+		Name:           "compute kubelet reservations",
+		CanRetry:       false,
+		ScriptExecutor: consts.LinuxBash,
+		ShellScript:    KubeletReservationScript,
+	})
+
+	collection.Append(ssh.Script{
+		Name:           "write kubelet drop-in config",
+		CanRetry:       false,
+		ScriptExecutor: consts.LinuxBash,
+		ShellScript:    KubeletDropInScript,
+	})
+
+	return collection
+}

--- a/pkg/bootstrap/distributions/kubelet_reservation.go
+++ b/pkg/bootstrap/distributions/kubelet_reservation.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Ksctl Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distributions
+
+// KubeletReservation holds computed GKE-style tiered resource reservations.
+type KubeletReservation struct {
+	KubeReservedCPU      int // millicores
+	KubeReservedMemory   int // MiB
+	SystemReservedCPU    int // millicores (fixed: 100)
+	SystemReservedMemory int // MiB (fixed: 200)
+}
+
+// ComputeKubeletReservation returns GKE-style tiered reservations
+// given the node's vCPU count and total memory in MiB.
+func ComputeKubeletReservation(vcpus, memoryMiB int) KubeletReservation {
+	return KubeletReservation{
+		KubeReservedCPU:      cpuReserved(vcpus),
+		KubeReservedMemory:   memReserved(memoryMiB),
+		SystemReservedCPU:    100,
+		SystemReservedMemory: 200,
+	}
+}
+
+func cpuReserved(cpus int) int {
+	milli := 0
+	if cpus >= 1 {
+		milli += 60
+	}
+	if cpus >= 2 {
+		milli += 10
+	}
+	if cpus >= 3 {
+		extra := min(cpus-2, 2)
+		milli += extra * 5
+	}
+	if cpus >= 5 {
+		above := cpus - 4
+		milli += above * 25 / 10
+	}
+	return milli
+}
+
+func memReserved(mem int) int {
+	reserved := 0
+	if mem <= 4096 {
+		reserved = mem * 25 / 100
+	} else if mem <= 8192 {
+		reserved = 4096*25/100 + (mem-4096)*20/100
+	} else if mem <= 16384 {
+		reserved = 4096*25/100 + 4096*20/100 + (mem-8192)*10/100
+	} else if mem <= 131072 {
+		reserved = 4096*25/100 + 4096*20/100 + 8192*10/100 + (mem-16384)*6/100
+	} else {
+		reserved = 4096*25/100 + 4096*20/100 + 8192*10/100 + 114688*6/100 + (mem-131072)*2/100
+	}
+	if reserved < 255 {
+		reserved = 255
+	}
+	return reserved
+}
+
+// KubeletReservationScript is a bash snippet that computes GKE-style tiered
+// kubelet kube-reserved values at bootstrap time using the node's actual
+// CPU count (nproc) and total memory (/proc/meminfo).
+//
+// It sets two shell variables:
+//   - KUBE_CPU  – millicores to reserve (e.g. 60, 70, 80)
+//   - KUBE_MEM  – mebibytes to reserve (minimum 255)
+//
+// The snippet is already %%-escaped so it can be embedded directly inside
+// fmt.Sprintf format strings.
+const KubeletReservationScript = `
+TOTAL_CPUS=$(nproc)
+TOTAL_MEM_MI=$(awk '/MemTotal/{printf "%%d", $2/1024}' /proc/meminfo)
+
+cpu_reserved() {
+  local cpus=$1
+  local milli=0
+  if [ "$cpus" -ge 1 ]; then milli=$((milli + 60)); fi
+  if [ "$cpus" -ge 2 ]; then milli=$((milli + 10)); fi
+  if [ "$cpus" -ge 3 ]; then
+    local extra=$((cpus - 2))
+    if [ "$extra" -gt 2 ]; then extra=2; fi
+    milli=$((milli + extra * 5))
+  fi
+  if [ "$cpus" -ge 5 ]; then
+    local above=$((cpus - 4))
+    milli=$((milli + above * 25 / 10))
+  fi
+  echo "$milli"
+}
+
+mem_reserved() {
+  local mem=$1
+  local reserved=0
+  if [ "$mem" -le 4096 ]; then
+    reserved=$((mem * 25 / 100))
+  elif [ "$mem" -le 8192 ]; then
+    reserved=$((4096 * 25 / 100 + (mem - 4096) * 20 / 100))
+  elif [ "$mem" -le 16384 ]; then
+    reserved=$((4096 * 25 / 100 + 4096 * 20 / 100 + (mem - 8192) * 10 / 100))
+  elif [ "$mem" -le 131072 ]; then
+    reserved=$((4096 * 25 / 100 + 4096 * 20 / 100 + 8192 * 10 / 100 + (mem - 16384) * 6 / 100))
+  else
+    reserved=$((4096 * 25 / 100 + 4096 * 20 / 100 + 8192 * 10 / 100 + 114688 * 6 / 100 + (mem - 131072) * 2 / 100))
+  fi
+  if [ "$reserved" -lt 255 ]; then reserved=255; fi
+  echo "$reserved"
+}
+
+KUBE_CPU=$(cpu_reserved "$TOTAL_CPUS")
+KUBE_MEM=$(mem_reserved "$TOTAL_MEM_MI")
+`

--- a/pkg/bootstrap/distributions/kubelet_reservation.go
+++ b/pkg/bootstrap/distributions/kubelet_reservation.go
@@ -166,17 +166,10 @@ echo 'KUBELET_EXTRA_ARGS=--config-dir=/etc/kubernetes/kubelet.conf.d' | sudo tee
 // Used for CP1+ and worker nodes.
 func ScriptKubeletDropIn(collection ssh.ExecutionPipeline) ssh.ExecutionPipeline {
 	collection.Append(ssh.Script{
-		Name:           "compute kubelet reservations",
+		Name:           "compute kubelet reservations and write drop-in config",
 		CanRetry:       false,
 		ScriptExecutor: consts.LinuxBash,
-		ShellScript:    KubeletReservationScript,
-	})
-
-	collection.Append(ssh.Script{
-		Name:           "write kubelet drop-in config",
-		CanRetry:       false,
-		ScriptExecutor: consts.LinuxBash,
-		ShellScript:    KubeletDropInScript,
+		ShellScript:    KubeletReservationScript + KubeletDropInScript,
 	})
 
 	return collection

--- a/pkg/bootstrap/distributions/kubelet_reservation_test.go
+++ b/pkg/bootstrap/distributions/kubelet_reservation_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Ksctl Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distributions
+
+import "testing"
+
+func TestComputeKubeletReservation(t *testing.T) {
+	tests := []struct {
+		name       string
+		vcpus      int
+		memoryMiB  int
+		wantCPU    int
+		wantMemory int
+	}{
+		{
+			name:       "1 vCPU, 1024 MiB (small node, hits 255 MiB minimum)",
+			vcpus:      1,
+			memoryMiB:  1024,
+			wantCPU:    60,
+			wantMemory: 256,
+		},
+		{
+			name:       "2 vCPU, 4096 MiB (common small instance)",
+			vcpus:      2,
+			memoryMiB:  4096,
+			wantCPU:    70,
+			wantMemory: 1024,
+		},
+		{
+			name:       "4 vCPU, 16384 MiB (standard instance)",
+			vcpus:      4,
+			memoryMiB:  16384,
+			wantCPU:    80,
+			wantMemory: 2662,
+		},
+		{
+			name:       "8 vCPU, 32768 MiB (larger instance)",
+			vcpus:      8,
+			memoryMiB:  32768,
+			wantCPU:    90,
+			wantMemory: 3645,
+		},
+		{
+			name:       "16 vCPU, 131072 MiB (large instance)",
+			vcpus:      16,
+			memoryMiB:  131072,
+			wantCPU:    110,
+			wantMemory: 9543,
+		},
+		{
+			name:       "96 vCPU, 196608 MiB (very large instance, hits top tier)",
+			vcpus:      96,
+			memoryMiB:  196608,
+			wantCPU:    310,
+			wantMemory: 10853,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ComputeKubeletReservation(tt.vcpus, tt.memoryMiB)
+
+			if got.KubeReservedCPU != tt.wantCPU {
+				t.Errorf("KubeReservedCPU = %d, want %d", got.KubeReservedCPU, tt.wantCPU)
+			}
+			if got.KubeReservedMemory != tt.wantMemory {
+				t.Errorf("KubeReservedMemory = %d, want %d", got.KubeReservedMemory, tt.wantMemory)
+			}
+			if got.SystemReservedCPU != 100 {
+				t.Errorf("SystemReservedCPU = %d, want 100", got.SystemReservedCPU)
+			}
+			if got.SystemReservedMemory != 200 {
+				t.Errorf("SystemReservedMemory = %d, want 200", got.SystemReservedMemory)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements the standardization of Kubelet resource reservations and eviction thresholds as discussed in #626.

Key changes:
- Standardized baseline: Reserving 200m CPU and 500Mi RAM for both OS and Kubelet.
- Implemented  thresholds to prevent node instability.
- Explicitly set  to ensure compatibility with the existing containerd setup.
- Updated K3s and Kubeadm bootstrapping logic and associated unit tests.

Fixes #626